### PR TITLE
更新jackson到2.12.0 #24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <lib.javasimon.version>3.5.2</lib.javasimon.version>
         <lib.dozer.version>5.5.1</lib.dozer.version>
         <lib.log.version>1.7.21</lib.log.version>
-        <lib.jackson.version>2.9.9</lib.jackson.version>
-        <lib.jackson.databind.version>2.9.10.5</lib.jackson.databind.version>
+        <lib.jackson.version>2.12.0</lib.jackson.version>
+        <lib.jackson.databind.version>2.12.0</lib.jackson.databind.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
现在的版本少了 com/fasterxml/jackson/databind/ser/std/ToStringSerializerBase 是一个bug
在使用 kubernetes-client 包的 DefaultKubernetesClient().load(InputStream is) 能够复现这个问题, 在更新到2.12.0之后解决了